### PR TITLE
fix an error in a string ("D0able" > "Double")

### DIFF
--- a/Example/multitap/index.js
+++ b/Example/multitap/index.js
@@ -24,7 +24,7 @@ export class PressBox extends Component {
   };
   _onDoubleTap = event => {
     if (event.nativeEvent.state === State.ACTIVE) {
-      alert('D0able tap, good job!');
+      alert('Double tap, good job!');
     }
   };
   render() {


### PR DESCRIPTION
## Description

Basic fix for an error in a string ("D0able" > "Double").

## Test plan

No impact on the rest of the code, only display the right word in the alert of multitap example. 